### PR TITLE
chore: .gitattributes で改行コードを LF に強制

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.bat text eol=crlf
+*.png binary
+*.jpg binary
+*.gif binary
+*.pdf binary


### PR DESCRIPTION
## Summary

- Windows runner で `pnpm format:check` が 186 ファイル全部 format 違反を報告していた問題への対処
- 原因は Windows の git autocrlf=true で checkout 時に CRLF が入り、oxfmt が LF 期待で diff として認識していたこと
- `.gitattributes` に `* text=auto eol=lf` を入れて全プラットフォームで LF 統一
- `*.bat` は CRLF、PDF/PNG/JPG/GIF はバイナリ扱い

## Test plan

- [ ] CI Windows ジョブの `pnpm format:check` がパスすることを確認
- [ ] CI Linux/macOS ジョブはこれまで通りパスすることを確認
- [ ] ローカル(macOS) で `pnpm format:check` が clean のままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)