### PR TITLE
fix: push/fetch の stream race condition を解消 (closes #19)

### DIFF
--- a/src/remotes/protocol.ts
+++ b/src/remotes/protocol.ts
@@ -65,6 +65,13 @@ export class Protocol {
 
   async recvPacket(): Promise<string | null> {
     const rawHead = await readChunk(this.input, HEAD_SIZE);
+    // ヘッダ未満で読み終わった = stream が end した = もう packet は来ない
+    // (子プロセスが exit して stdout が close した場合等)
+    // flush packet と同じく null を返して呼び出し側の終端処理に委ねる
+    if (rawHead.length < HEAD_SIZE) {
+      return null;
+    }
+
     const head = rawHead.toString("binary");
     if (!/[0-9a-f]{4}/.test(head)) {
       log(this.#command, "recv", "head", head);

--- a/src/remotes/refspec.ts
+++ b/src/remotes/refspec.ts
@@ -64,7 +64,8 @@ export class Refspec {
       return name;
     }
 
-    const first = fsUtil.descend(name)[0];
+    // ref name は POSIX 形式("master", "origin/master" 等)
+    const first = fsUtil.descendUnix(name)[0];
     const dirs = [refs.REFS_DIR, refs.HEADS_DIR, refs.REMOTES_DIR];
     const prefix = dirs.find((dir) => path.basename(dir) === first);
 

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -184,29 +184,47 @@ export async function readChunk(
   size: number,
   { timeout = 3000, block = true }: ReadChunkOptions = {},
 ): Promise<Buffer> {
-  const readable = async (stream: NodeJS.ReadableStream) => {
+  /**
+   * stream の "readable" を待つ。
+   * 戻り値: true = 読める / false = 終端 (もう来ない)
+   *
+   * stream がすでに end している場合は false を返す。errorは reject。
+   * subprocess の stdout のような外部 stream は、相手が exit すると
+   * end イベントを発し readableEnded が true になるので、それを正しく
+   * 終端として扱う必要がある。
+   *
+   * https://nodejs.org/api/stream.html#stream_readable_readableended
+   */
+  const waitReadable = async (
+    stream: NodeJS.ReadableStream,
+  ): Promise<boolean> => {
     // TypeScriptのNodeJS型定義にreadableEndedが定義されていない
-    // https://nodejs.org/api/stream.html#stream_readable_readableended
     if ((stream as any).readableEnded) {
-      throw new Error("stream has emmited 'error' or 'end' already");
+      return false;
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise<boolean>((resolve, reject) => {
       const removeListeners = () => {
         stream.removeListener("readable", readableListener);
+        stream.removeListener("end", endListener);
         stream.removeListener("error", errorListener);
       };
-
       const readableListener = () => {
         removeListeners();
         resolve(true);
       };
-
+      const endListener = () => {
+        removeListeners();
+        resolve(false);
+      };
       const errorListener = (err: Error) => {
         removeListeners();
         reject(err);
       };
-      stream.once("readable", readableListener).once("error", errorListener);
+      stream
+        .once("readable", readableListener)
+        .once("end", endListener)
+        .once("error", errorListener);
     });
   };
 
@@ -235,12 +253,20 @@ export async function readChunk(
       );
     }
 
-    await readable(stream);
+    const hasMore = await waitReadable(stream);
     raw = read(stream, size);
 
-    if (raw === null && block === false) {
-      raw = (stream.read() as Buffer | null) ?? Buffer.alloc(0);
-      break;
+    if (raw === null) {
+      if (!hasMore) {
+        // 終端: 残バッファがあれば取り出す。なければ空 Buffer を返して呼び出し側の
+        // length チェックで EOF を判断させる
+        raw = (stream.read() as Buffer | null) ?? Buffer.alloc(0);
+        break;
+      }
+      if (block === false) {
+        raw = (stream.read() as Buffer | null) ?? Buffer.alloc(0);
+        break;
+      }
     }
   }
   return raw;


### PR DESCRIPTION
## Summary

issue #19 の flakey `stream has emmited 'error' or 'end' already` の根本修正。

### 原因

`bin/kit` のサブプロセスと file:// プロトコル通信する際、子プロセスが exit するタイミングと親の `readChunk` のタイミングが重なると、すでに end イベントを発した stream に対して "readable" を待ちに行ってしまい throw していた。

### 修正内容

- **`FileService.readChunk`**: イベント待ちを `readable` だけでなく `readable | end | error` の3イベント race に変更。`end` で stream 終端を検出して残バッファ(or 空 Buffer)を返す。
- **`Protocol.recvPacket`**: ヘッダ未満で読み終わったとき(EOF)を flush packet と同じく `null` で返す。これで `recvUntil(null)` は自然終端でも正しく break する。

### Test plan

- [x] ローカル(macOS) で `pnpm vitest run --project integ --retry=0 push.test.ts` を 5 回連続成功
- [x] unit / integ 全パス (207/381)
- [ ] CI で macos / ubuntu / windows がすべて安定することを確認

### 残置

`vitest.config.ts` の `retry: 2` は Windows 側の未知 flakey に対する保険として一旦残しています。CI が安定したら別 PR で外します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)