### PR TITLE
ci: Windows continue-on-error と vitest retry を外す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # Windows は path 区切り周りで未解決の問題があるため失敗してもジョブ全体は通す
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
           name: "integ",
           include: ["integ/**/*.test.ts"],
           testTimeout: 30_000,
-          retry: 2,
           // 統合テストはサブプロセス起動とファイルシステム共有があるため
           // worker thread でなく forks (プロセス分離) で安定させる
           pool: "forks",


### PR DESCRIPTION
## Summary

CI の "緩和策" を外して厳しい gate に戻す。

### 背景

- PR #22 で stream race condition を根本修正済み
- PR #23 / #24 で Windows 失敗ケースは skip 化済み
- 結果として Windows でも CI が安定して green になった

そこで、暫定対応として残していた以下の "緩和策" を外す。

### 変更内容

- **\`.github/workflows/ci.yml\`**: Windows の \`continue-on-error: true\` を削除
  - Windows ジョブが本当に green になることを必須化
  - 新規 regression を早期検知できる
- **\`vitest.config.ts\`**: integ プロジェクトの \`retry: 2\` を削除
  - flakey の根本原因(stream race)は解消済み
  - retry を残すと別の flakey を 2 回まで隠す副作用があるため

## Test plan

- [x] ローカル(macOS) で integ を retry なし実行して安定確認
- [ ] CI で 3 OS とも green
- [ ] continue-on-error を外しても Windows が gate ブロックしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)