### PR TITLE
refactor(FileService): waitReadable を Promise.withResolvers でフラット化

### DIFF
--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -196,36 +196,38 @@ export async function readChunk(
    * https://nodejs.org/api/stream.html#stream_readable_readableended
    */
   const waitReadable = async (
-    stream: NodeJS.ReadableStream,
+    streamLike: NodeJS.ReadableStream,
   ): Promise<boolean> => {
-    // TypeScriptのNodeJS型定義にreadableEndedが定義されていない
-    if ((stream as any).readableEnded) {
+    // 引数の型は最小 interface だが、実際に渡るインスタンスは
+    // Readable (child_process の stdout 等) なので readableEnded が利用可能。
+    const stream = streamLike as Readable;
+    if (stream.readableEnded) {
       return false;
     }
 
-    return new Promise<boolean>((resolve, reject) => {
-      const removeListeners = () => {
-        stream.removeListener("readable", readableListener);
-        stream.removeListener("end", endListener);
-        stream.removeListener("error", errorListener);
-      };
-      const readableListener = () => {
-        removeListeners();
-        resolve(true);
-      };
-      const endListener = () => {
-        removeListeners();
-        resolve(false);
-      };
-      const errorListener = (err: Error) => {
-        removeListeners();
-        reject(err);
-      };
-      stream
-        .once("readable", readableListener)
-        .once("end", endListener)
-        .once("error", errorListener);
-    });
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    const removeListeners = () => {
+      stream.removeListener("readable", readableListener);
+      stream.removeListener("end", endListener);
+      stream.removeListener("error", errorListener);
+    };
+    const readableListener = () => {
+      removeListeners();
+      resolve(true);
+    };
+    const endListener = () => {
+      removeListeners();
+      resolve(false);
+    };
+    const errorListener = (err: Error) => {
+      removeListeners();
+      reject(err);
+    };
+    stream
+      .once("readable", readableListener)
+      .once("end", endListener)
+      .once("error", errorListener);
+    return promise;
   };
 
   const read = (stream: NodeJS.ReadableStream, size: number): Buffer | null =>


### PR DESCRIPTION
## Summary

PR #22 のレビューコメント 2件への対応:

- L202 \"これって今のバージョンでも定義されていない?\"
  - \`readableEnded\` は \`@types/node\` の \`Readable\` には定義済み(\`stream.d.ts\` に \`readonly readableEnded: boolean\`)
  - 引数型 \`NodeJS.ReadableStream\` だけが loose で持っていなかったため \`as any\` を使っていた
  - 実際のインスタンスは \`Readable\` なので narrowing して \`as any\` を排除

- L206 \"Promise.withResolvers でネストが減らせて見通しが良くなるかも\"
  - Node 22+ で利用可能 (mise.toml は node = \"25\")
  - \`new Promise((resolve, reject) => { ... })\` の中でリスナーを定義していた構造を、関数本体直下にフラットに展開

挙動変更なし。

## Test plan

- [x] tsc --noEmit clean
- [x] unit / integ テスト全パス維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)