### PR TITLE
refactor: NodeJS.ReadableStream を Readable に統一

### DIFF
--- a/src/pack/stream.ts
+++ b/src/pack/stream.ts
@@ -1,12 +1,13 @@
 import * as crypto from "crypto";
 import * as fs from "fs";
+import { Readable } from "node:stream";
 import { readChunk } from "../services";
 import { Pathname } from "../types";
 import * as fsUtil from "../util/fs";
 import * as pack from "./pack";
 import { InvalidPack } from "./pack";
 export class Stream implements fsUtil.Seekable {
-  #input: NodeJS.ReadableStream;
+  #input: Readable;
   digest = crypto.createHash("sha1");
   offset = 0;
   #buffer = Buffer.alloc(0);
@@ -16,7 +17,7 @@ export class Stream implements fsUtil.Seekable {
     return new Stream(fs.createReadStream(pathname));
   }
 
-  constructor(input: NodeJS.ReadableStream, prefix = "") {
+  constructor(input: Readable, prefix = "") {
     this.#input = input;
     this.#buffer = Buffer.concat([this.#buffer, Buffer.from(prefix, "utf8")]);
   }

--- a/src/remotes/protocol.ts
+++ b/src/remotes/protocol.ts
@@ -1,3 +1,4 @@
+import { Readable } from "node:stream";
 import { readChunk } from "../services/FileService";
 import * as array from "../util/collection";
 
@@ -38,7 +39,7 @@ export class Protocol {
   #capsSent = false;
   constructor(
     command: string,
-    public input: NodeJS.ReadableStream,
+    public input: Readable,
     public output: NodeJS.WritableStream,
     capabilities: string[] = [],
   ) {

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -180,7 +180,7 @@ interface ReadChunkOptions {
  * @param timeout タイムアウト(ms)
  */
 export async function readChunk(
-  stream: NodeJS.ReadableStream,
+  stream: Readable,
   size: number,
   { timeout = 3000, block = true }: ReadChunkOptions = {},
 ): Promise<Buffer> {
@@ -195,12 +195,7 @@ export async function readChunk(
    *
    * https://nodejs.org/api/stream.html#stream_readable_readableended
    */
-  const waitReadable = async (
-    streamLike: NodeJS.ReadableStream,
-  ): Promise<boolean> => {
-    // 引数の型は最小 interface だが、実際に渡るインスタンスは
-    // Readable (child_process の stdout 等) なので readableEnded が利用可能。
-    const stream = streamLike as Readable;
+  const waitReadable = async (stream: Readable): Promise<boolean> => {
     if (stream.readableEnded) {
       return false;
     }
@@ -230,7 +225,7 @@ export async function readChunk(
     return promise;
   };
 
-  const read = (stream: NodeJS.ReadableStream, size: number): Buffer | null =>
+  const read = (stream: Readable, size: number): Buffer | null =>
     stream.read(size) as Buffer | null;
 
   let raw = read(stream, size);


### PR DESCRIPTION
## Summary

PR #26 のレビュー流れで議論した型整理。

\`NodeJS.ReadableStream\` は @types/node の global namespace に置かれた **ダックタイピング向けの最小 interface** で、\`readableEnded\` / \`readableHighWaterMark\` 等の状態系プロパティを持たない。これは "stream っぽい何か" を最小契約で受けるためのもので、Node 0.x 時代の legacy stream や自作 stream-like を許容するために存在している。

本コードベースは Node.js 上で動かす前提で、実際に渡るインスタンスはすべて \`Readable\` (child_process.spawn の stdout, fs.createReadStream の戻り値等) なので、最初から \`Readable\` を型として要求するほうが正確で、PR #26 で残っていた \`as Readable\` キャストも不要になる。

## 変更点

- \`src/services/FileService.ts\`: \`readChunk\` の引数 / \`waitReadable\` の引数
- \`src/remotes/protocol.ts\`: \`Protocol.input\`
- \`src/pack/stream.ts\`: \`Stream.#input\` と constructor

挙動変更なし。

## Test plan

- [x] tsc --noEmit clean
- [x] unit (207) / integ (381) 全パス
- [ ] CI 3 OS green

🤖 Generated with [Claude Code](https://claude.com/claude-code)