### PR TITLE
refactor: dev hygiene 整理 (node: プレフィックス + vitest explicit + VS Code)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,35 +1,66 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
+  "inputs": [
+    {
+      "id": "kitArgs",
+      "type": "promptString",
+      "description": "kit に渡す引数 (例: status / commit -m foo)",
+      "default": "status"
+    },
+    {
+      "id": "cwd",
+      "type": "promptString",
+      "description": "kit を実行する作業ディレクトリ (絶対パス)",
+      "default": "${workspaceFolder}"
+    }
+  ],
   "configurations": [
     {
       "type": "node",
-      // vscode jest extension
-      "name": "vscode-jest-tests",
       "request": "launch",
-      // https://medium.com/@jakubsynowiec/debugging-typescript-jest-unit-tests-with-visual-studio-code-36cd16865bb0
-      "args": ["--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
-      "cwd": "${workspaceFolder}",
+      "name": "kit (current args + cwd)",
+      "program": "${workspaceFolder}/packages/cli/dist/main.js",
+      "args": [],
+      "cwd": "${input:cwd}",
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      // https://stackoverflow.com/questions/37771097/how-to-debug-async-await-in-visual-studio-code
-      "skipFiles": ["inspector_async_hook.js", "async_hooks.js"],
-      "env": {
-        // デバッグ時はtimeoutを長くする
-        // https://stackoverflow.com/questions/69137737/what-is-the-best-way-to-automatically-set-jest-timeout-when-debugging-tests
-        "DEBUG": "jest"
-      }
+      "skipFiles": ["<node_internals>/**"],
+      "outFiles": ["${workspaceFolder}/packages/*/dist/**/*.js"],
+      "sourceMaps": true,
+      "preLaunchTask": "build:release"
     },
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Program",
+      "name": "vitest: current file",
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "--no-file-parallelism", "${relativeFile}"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
       "skipFiles": ["<node_internals>/**"],
-      "program": "${workspaceFolder}/dist/main.js",
-      "outFiles": ["${workspaceFolder}/**/*.js"]
+      "smartStep": true
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "vitest: all unit",
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "--project", "unit"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"],
+      "smartStep": true
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "vitest: all integ",
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "--project", "integ"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"],
+      "smartStep": true,
+      "preLaunchTask": "build:release"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,15 +2,15 @@
   "files.exclude": {
     "**/*.d.ts": true,
     "**/*.map": true,
-    "integ/**/*.js": true,
-    "src/**/*.js": true
+    "packages/*/dist": true,
+    "packages/*/integ/**/*.js": true,
+    "packages/*/src/**/*.js": true,
+    "**/*.tsbuildinfo": true
   },
-  "jest.jestCommandLine": "npx jest --config ./jest.config.js",
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "explicit"
-    }
-  }
+    "editor.formatOnSave": true
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build:release",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["build:release"],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": ["$tsc"]
+    },
+    {
+      "label": "build:dev",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["build:dev"],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": ["$tsc"]
+    },
+    {
+      "label": "test:unit",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["test:unit"],
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "test:integ",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["test:integ"],
+      "group": "test",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@rtamura30/kit",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.33.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/r-tamura/building-git-typescript.git"

--- a/packages/cli/integ/command/add.test.ts
+++ b/packages/cli/integ/command/add.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { stripIndent } from "@kit/core/util";
 import * as T from "./helper";
 import { itOnlyUnix } from "./helper";

--- a/packages/cli/integ/command/branch.test.ts
+++ b/packages/cli/integ/command/branch.test.ts
@@ -1,5 +1,6 @@
-import * as fsCb from "fs";
-import * as path from "path";
+import { describe, it, beforeEach, afterEach } from "vitest";
+import * as fsCb from "node:fs";
+import * as path from "node:path";
 import assert from "node:assert";
 import { asserts, stripIndent } from "@kit/core/util";
 import * as T from "./helper";

--- a/packages/cli/integ/command/checkout.test.ts
+++ b/packages/cli/integ/command/checkout.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import assert from "node:assert";
 import { stripIndent } from "@kit/core/util";
 import * as T from "./helper";

--- a/packages/cli/integ/command/cherry_pick.test.ts
+++ b/packages/cli/integ/command/cherry_pick.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import assert from "node:assert";
 import { CompleteCommit, Dict } from "@kit/core/types";
 import { stripIndent } from "@kit/core/util";

--- a/packages/cli/integ/command/commit.test.ts
+++ b/packages/cli/integ/command/commit.test.ts
@@ -1,4 +1,5 @@
-import * as path from "path";
+import { describe, it, beforeEach, afterEach, vi } from "vitest";
+import * as path from "node:path";
 import assert from "node:assert";
 import { Editor } from "../../src/editor";
 import { RevList } from "@kit/core/rev_list";

--- a/packages/cli/integ/command/config.test.ts
+++ b/packages/cli/integ/command/config.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import { stripIndent } from "@kit/core/util";
 import * as T from "./helper";
 

--- a/packages/cli/integ/command/diff.test.ts
+++ b/packages/cli/integ/command/diff.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import * as T from "./helper";
 import { itOnlyUnix } from "./helper";
 import { stripIndent } from "@kit/core/util";

--- a/packages/cli/integ/command/fetch.test.ts
+++ b/packages/cli/integ/command/fetch.test.ts
@@ -1,6 +1,7 @@
-import * as fsCb from "fs";
-import * as fs from "fs/promises";
-import * as path from "path";
+import { describe, it, beforeEach, afterEach } from "vitest";
+import * as fsCb from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import assert from "node:assert";
 import { Repository } from "@kit/core/repository";
 import * as revlist from "@kit/core/rev_list";

--- a/packages/cli/integ/command/helper.ts
+++ b/packages/cli/integ/command/helper.ts
@@ -1,8 +1,9 @@
+import { describe, it, vi } from "vitest";
 import type { Mock } from "vitest";
-import { promises } from "fs";
-import * as path from "path";
+import { promises } from "node:fs";
+import * as path from "node:path";
 import assert from "node:assert";
-import { Readable, Writable } from "stream";
+import { Readable, Writable } from "node:stream";
 import { makeLogger } from "@kit/core/__test__/util";
 import * as Command from "../../src/command";
 import { Blob } from "@kit/core/database";

--- a/packages/cli/integ/command/init.test.ts
+++ b/packages/cli/integ/command/init.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, afterEach } from "vitest";
 import * as fsCb from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/packages/cli/integ/command/log.test.ts
+++ b/packages/cli/integ/command/log.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import * as T from "./helper";
 import { OID } from "@kit/core/types";
 import { stripIndent } from "@kit/core/util";

--- a/packages/cli/integ/command/merge.test.ts
+++ b/packages/cli/integ/command/merge.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import * as T from "./helper";
 import { describeOnlyUnix } from "./helper";
 import assert from "node:assert";

--- a/packages/cli/integ/command/push.test.ts
+++ b/packages/cli/integ/command/push.test.ts
@@ -1,6 +1,7 @@
-import * as fsCb from "fs";
-import * as fs from "fs/promises";
-import * as path from "path";
+import { describe, it, beforeEach, afterEach } from "vitest";
+import * as fsCb from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import assert from "node:assert";
 import { Repository } from "@kit/core/repository";
 import * as revlist from "@kit/core/rev_list";

--- a/packages/cli/integ/command/remote.test.ts
+++ b/packages/cli/integ/command/remote.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import { stripIndent } from "@kit/core/util";
 import * as T from "./helper";
 

--- a/packages/cli/integ/command/remote_repo.ts
+++ b/packages/cli/integ/command/remote_repo.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { TestUtil } from "./helper";
 
 export class RemoteRepo extends TestUtil {

--- a/packages/cli/integ/command/reset.test.ts
+++ b/packages/cli/integ/command/reset.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import { CompleteCommit, OID } from "@kit/core/types";
 import assert from "node:assert";
 import * as T from "./helper";

--- a/packages/cli/integ/command/revert.test.ts
+++ b/packages/cli/integ/command/revert.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import assert from "node:assert";
 import { CompleteCommit, Dict } from "@kit/core/types";
 import * as TextUtil from "@kit/core/util/text";

--- a/packages/cli/integ/command/rm.test.ts
+++ b/packages/cli/integ/command/rm.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import assert from "node:assert";
 import { stripIndent } from "@kit/core/util";
 import * as T from "./helper";

--- a/packages/cli/integ/command/status.test.ts
+++ b/packages/cli/integ/command/status.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach } from "vitest";
 import * as T from "./helper";
 import { itOnlyUnix } from "./helper";
 import { stripIndent } from "@kit/core/util";

--- a/packages/cli/src/command/base.ts
+++ b/packages/cli/src/command/base.ts
@@ -1,5 +1,5 @@
 import arg, { type Spec } from "@kit/core/util/arg";
-import * as path from "path";
+import * as path from "node:path";
 import * as Color from "../color";
 import { EditCallback, Editor } from "../editor";
 import { Pager } from "../pager";

--- a/packages/cli/src/command/log.ts
+++ b/packages/cli/src/command/log.ts
@@ -1,5 +1,5 @@
-import { AssertionError } from "assert";
-import * as os from "os";
+import { AssertionError } from "node:assert";
+import * as os from "node:os";
 import { Style } from "../color";
 import { Change, Entry } from "@kit/core/database";
 import { SymRef } from "@kit/core/refs";

--- a/packages/cli/src/command/shared/remote_agent.ts
+++ b/packages/cli/src/command/shared/remote_agent.ts
@@ -1,5 +1,5 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as remotes from "@kit/core/remotes";
 import { Repository, RepositoryEnv } from "@kit/core/repository";
 import { Pathname } from "@kit/core/types";

--- a/packages/cli/src/command/shared/remote_client.test.ts
+++ b/packages/cli/src/command/shared/remote_client.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { buildAgentCommand } from "./remote_client";
 

--- a/packages/cli/src/command/shared/remote_client.ts
+++ b/packages/cli/src/command/shared/remote_client.ts
@@ -1,5 +1,5 @@
-import * as child_process from "child_process";
-import { URL } from "url";
+import * as child_process from "node:child_process";
+import { URL } from "node:url";
 import * as remotes from "@kit/core/remotes";
 import { OID } from "@kit/core/types";
 import * as array from "@kit/core/util/array";

--- a/packages/cli/src/command/shared/write_commit.ts
+++ b/packages/cli/src/command/shared/write_commit.ts
@@ -1,5 +1,5 @@
 import arg, { type Handler, type Spec } from "@kit/core/util/arg";
-import * as path from "path";
+import * as path from "node:path";
 import { Author, Commit, Tree } from "@kit/core/database";
 import {
   Error,

--- a/packages/cli/src/editor.ts
+++ b/packages/cli/src/editor.ts
@@ -1,7 +1,7 @@
-import { spawnSync, SpawnSyncReturns } from "child_process";
-import * as fsCallback from "fs";
-import { O_CREAT, O_TRUNC, O_WRONLY } from "constants";
-import { promises } from "fs";
+import { spawnSync, SpawnSyncReturns } from "node:child_process";
+import * as fsCallback from "node:fs";
+import { O_CREAT, O_TRUNC, O_WRONLY } from "node:constants";
+import { promises } from "node:fs";
 import { FileService, Process } from "@kit/core/services";
 import { Nullable, Pathname } from "@kit/core/types";
 import { split as shlexSplit } from "@kit/core/util/shlex";

--- a/packages/cli/src/pager.ts
+++ b/packages/cli/src/pager.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { spawn } from "node:child_process";
 import { Process } from "@kit/core/services";
 
 const PAGER_CMD = "less";

--- a/packages/cli/tsconfig.prod.json
+++ b/packages/cli/tsconfig.prod.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "noEmit": false,
-    "rewriteRelativeImportExtensions": true
+    "rewriteRelativeImportExtensions": true,
+    "sourceMap": true
   },
   "exclude": ["src/**/*.test.ts", "src/__test__/**"],
   "references": [{ "path": "../core/tsconfig.prod.json" }]

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -16,7 +16,6 @@ export default defineConfig({
     ],
   },
   test: {
-    globals: true,
     projects: [
       {
         extends: true,

--- a/packages/core/src/__test__/assert.ts
+++ b/packages/core/src/__test__/assert.ts
@@ -1,3 +1,4 @@
+import { expect } from "vitest";
 import { ErrorConstructor } from "../util";
 
 export async function assertAsyncError(

--- a/packages/core/src/__test__/fs.ts
+++ b/packages/core/src/__test__/fs.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import type { Mock } from "vitest";
 import { Stats } from "node:fs";
 import { FileHandle } from "node:fs/promises";

--- a/packages/core/src/__test__/util.ts
+++ b/packages/core/src/__test__/util.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import type { Mock } from "vitest";
 import { Logger } from "../services";
 import { GitObject, CompleteGitObject, OID } from "../types";

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1,5 +1,6 @@
-import { promises as fs } from "fs";
-import * as path from "path";
+import { describe, it, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 import assert from "node:assert";
 import { rmrf } from "../services";
 import { posixJoin, PosixPath, stripIndent } from "../util";

--- a/packages/core/src/config/stack.ts
+++ b/packages/core/src/config/stack.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { Pathname } from "../types";
 import { includes, last } from "../util/array";
 import { posixPath } from "../util/fs";

--- a/packages/core/src/database/author.test.ts
+++ b/packages/core/src/database/author.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, vi } from "vitest";
 import assert from "node:assert";
 import { Author } from "./author";
 

--- a/packages/core/src/database/backends.ts
+++ b/packages/core/src/database/backends.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { defaultFs } from "../services";
 import { OID, Pathname } from "../types";
 import * as errorUtil from "../util";

--- a/packages/core/src/database/commit.test.ts
+++ b/packages/core/src/database/commit.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, afterEach, vi } from "vitest";
 import assert from "node:assert";
 import { toLF } from "../util";
 import { Author } from "./author";

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 import { PathFilter } from "../path_filter";
 import { defaultFs, defaultZlib, FileService, Zlib } from "../services";
 import {
@@ -24,7 +24,7 @@ import { Entry } from "./entry";
 import { GitObjectType } from "./loose";
 import { Tree } from "./tree";
 import { TreeDiff } from "./tree_diff";
-import path = require("path");
+import path = require("node:path");
 
 type Rand = {
   sample: (str: string) => string;

--- a/packages/core/src/database/loose.ts
+++ b/packages/core/src/database/loose.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
-import { constants } from "zlib";
+import * as path from "node:path";
+import { constants } from "node:zlib";
 import { Backend, Raw } from ".";
 import { defaultFs, defaultZlib, FileService, Zlib } from "../services";
 import { TempFile } from "../tempfile";

--- a/packages/core/src/database/tree.test.ts
+++ b/packages/core/src/database/tree.test.ts
@@ -1,4 +1,5 @@
-import type { Stats } from "fs";
+import { describe, it, beforeEach, vi } from "vitest";
+import type { Stats } from "node:fs";
 import assert from "node:assert";
 import * as Database from ".";
 import { makeDummyFileStats, mockFsStats } from "../__test__/fs.ts";

--- a/packages/core/src/database/tree_diff.test.ts
+++ b/packages/core/src/database/tree_diff.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, afterEach, vi } from "vitest";
 import assert from "node:assert";
 import { PathFilter, Trie } from "../path_filter";
 import { GitObject } from "../types";

--- a/packages/core/src/diff/diff.test.ts
+++ b/packages/core/src/diff/diff.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { stripIndent } from "../util";
 import { combined } from "./diff";

--- a/packages/core/src/diff/hunk.test.ts
+++ b/packages/core/src/diff/hunk.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import { lines, TextDocument, Line, combinedHunk } from "./diff";
 import { Myers, Edit } from "./myers";
 import { Hunk } from "./hunk";

--- a/packages/core/src/diff/myers.test.ts
+++ b/packages/core/src/diff/myers.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { TextDocument, lines } from "./diff";
 import { Myers } from "./myers";

--- a/packages/core/src/entry.test.ts
+++ b/packages/core/src/entry.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { mockFsStats } from "./__test__/fs.ts";
 import { Entry } from "./entry.ts";

--- a/packages/core/src/entry.ts
+++ b/packages/core/src/entry.ts
@@ -1,5 +1,5 @@
-import { Stats } from "fs";
-import * as path from "path";
+import { Stats } from "node:fs";
+import * as path from "node:path";
 import * as Database from "./database";
 import * as Index from "./gindex";
 import { OID, Pathname } from "./types";

--- a/packages/core/src/gindex/__test__/fakeIndex.ts
+++ b/packages/core/src/gindex/__test__/fakeIndex.ts
@@ -1,6 +1,6 @@
 // 2 ファイル
 
-import { FileReadOptions, FileReadResult } from "fs/promises";
+import { FileReadOptions, FileReadResult } from "node:fs/promises";
 
 // 2 files
 export const fakeFiles = {

--- a/packages/core/src/gindex/checksum.test.ts
+++ b/packages/core/src/gindex/checksum.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeAll, vi } from "vitest";
 import assert from "node:assert";
 import { Checksum } from "./checksum";
 

--- a/packages/core/src/gindex/checksum.ts
+++ b/packages/core/src/gindex/checksum.ts
@@ -1,4 +1,4 @@
-import { Hash, createHash } from "crypto";
+import { Hash, createHash } from "node:crypto";
 import { IOHandle } from "../types";
 import { BaseError, Invalid } from "../util";
 

--- a/packages/core/src/gindex/entry.test.ts
+++ b/packages/core/src/gindex/entry.test.ts
@@ -1,4 +1,5 @@
-import * as path from "path";
+import { describe, it } from "vitest";
+import * as path from "node:path";
 import assert from "node:assert";
 import { makeDummyFileStats } from "../__test__";
 import { Entry } from "./entry";

--- a/packages/core/src/gindex/entry.ts
+++ b/packages/core/src/gindex/entry.ts
@@ -1,5 +1,5 @@
-import { Stats } from "fs";
-import * as path from "path";
+import { Stats } from "node:fs";
+import * as path from "node:path";
 import * as Database from "../database";
 import { MODE } from "../entry";
 import { OID, Pathname } from "../types";

--- a/packages/core/src/gindex/gindex.test.ts
+++ b/packages/core/src/gindex/gindex.test.ts
@@ -1,6 +1,7 @@
-import * as crypto from "crypto";
-import { promises as fsPromises } from "fs";
-import * as path from "path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as crypto from "node:crypto";
+import { promises as fsPromises } from "node:fs";
+import * as path from "node:path";
 import assert from "node:assert";
 import { makeDummyFileStats } from "../__test__";
 import * as Database from "../database";

--- a/packages/core/src/gindex/gindex.ts
+++ b/packages/core/src/gindex/gindex.ts
@@ -2,7 +2,7 @@
  * Note: index.jsはNodeJSでは特別な扱いをされるためgitのindexを扱う機能のファイル名はgindex.js (git index) とする
  */
 import assert from "node:assert";
-import { Stats, constants } from "fs";
+import { Stats, constants } from "node:fs";
 import * as Database from "../database";
 import { Lockfile, LockfileEnvironment } from "../lockfile";
 import { FileService, defaultFs } from "../services";

--- a/packages/core/src/lockfile.test.ts
+++ b/packages/core/src/lockfile.test.ts
@@ -1,6 +1,7 @@
-import { constants } from "fs";
-import * as fs from "fs/promises";
-import * as path from "path";
+import { describe, it, expect, afterEach, beforeAll, vi } from "vitest";
+import { constants } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import assert from "node:assert";
 import { EACCES, EEXIST, ENOENT } from "./__test__";
 import { Lockfile, MissingParent, NoPermission } from "./lockfile";

--- a/packages/core/src/lockfile.ts
+++ b/packages/core/src/lockfile.ts
@@ -1,5 +1,5 @@
-import { constants, promises } from "fs";
-import * as path from "path";
+import { constants, promises } from "node:fs";
+import * as path from "node:path";
 import { LockDenied } from "./refs";
 import { defaultFs, FileService } from "./services";
 import { IOHandle } from "./types";

--- a/packages/core/src/merge/diff3.test.ts
+++ b/packages/core/src/merge/diff3.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import { Diff3 } from "./diff3";
 import assert from "node:assert";
 import { stripIndent } from "../util";

--- a/packages/core/src/merge/resolve.ts
+++ b/packages/core/src/merge/resolve.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { Blob, ChangeMap, Entry } from "../database";
 import { ModeNumber } from "../entry";
 import { Repository } from "../repository";

--- a/packages/core/src/pack/delta.test.ts
+++ b/packages/core/src/pack/delta.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { VarIntLE } from "./numbers";
 import { Xdelta } from "./xdelta";

--- a/packages/core/src/pack/entry.ts
+++ b/packages/core/src/pack/entry.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import * as database from "../database";
 import { OID, Pathname } from "../types";
 import * as binary from "../util/binary";

--- a/packages/core/src/pack/expander.test.ts
+++ b/packages/core/src/pack/expander.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { Expander } from "./expander";
 import { VarIntLE } from "./numbers";

--- a/packages/core/src/pack/indexer.ts
+++ b/packages/core/src/pack/indexer.ts
@@ -1,6 +1,6 @@
 import * as crc32lib from "crc-32";
-import * as crypto from "crypto";
-import * as path from "path";
+import * as crypto from "node:crypto";
+import * as path from "node:path";
 import { IDX_SIGNATURE, Reader, SIGNATURE, Stream, VERSION } from ".";
 import * as database from "../database";
 import * as progress from "../progress";

--- a/packages/core/src/pack/numbers.ts
+++ b/packages/core/src/pack/numbers.ts
@@ -1,4 +1,4 @@
-import * as stream from "stream";
+import * as stream from "node:stream";
 import * as FileService from "../services";
 import { asserts } from "../util";
 import * as iter from "../util/iter";

--- a/packages/core/src/pack/reader.ts
+++ b/packages/core/src/pack/reader.ts
@@ -1,5 +1,5 @@
-import { TextDecoder } from "util";
-import * as zlib from "zlib";
+import { TextDecoder } from "node:util";
+import * as zlib from "node:zlib";
 import { defaultZlib, Zlib } from "../services";
 import { asserts, includes, isNodeError } from "../util";
 import * as array from "../util/array";

--- a/packages/core/src/pack/stream.ts
+++ b/packages/core/src/pack/stream.ts
@@ -1,5 +1,5 @@
-import * as crypto from "crypto";
-import * as fs from "fs";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
 import { Readable } from "node:stream";
 import { readChunk } from "../services";
 import { Pathname } from "../types";

--- a/packages/core/src/pack/writer.ts
+++ b/packages/core/src/pack/writer.ts
@@ -1,5 +1,5 @@
-import * as crypto from "crypto";
-import { constants } from "zlib";
+import * as crypto from "node:crypto";
+import { constants } from "node:zlib";
 import * as database from "../database";
 import { Progress } from "../progress";
 import { RevList } from "../rev_list";

--- a/packages/core/src/pack/xdelta.test.ts
+++ b/packages/core/src/pack/xdelta.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { Copy, Insert } from "./delta";
 import { Operation, Xdelta } from "./xdelta";

--- a/packages/core/src/path_filter.ts
+++ b/packages/core/src/path_filter.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { EntryMap } from "./database";
 import { Pathname } from "./types";
 import { isempty } from "./util";

--- a/packages/core/src/refs.test.ts
+++ b/packages/core/src/refs.test.ts
@@ -1,6 +1,7 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import type { Mock, MockInstance } from "vitest";
-import * as os from "os";
-import * as path from "path";
+import * as os from "node:os";
+import * as path from "node:path";
 import assert from "node:assert";
 import { mockFs, mockFsError } from "./__test__";
 import { Lockfile } from "./lockfile";

--- a/packages/core/src/refs.ts
+++ b/packages/core/src/refs.ts
@@ -1,5 +1,5 @@
-import * as os from "os";
-import * as path from "path";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Lockfile, MissingParent } from "./lockfile";
 import { defaultFs, directory, exists, FileService } from "./services";
 import { Nullable, OID, Pathname } from "./types";

--- a/packages/core/src/repository/hard_reset.ts
+++ b/packages/core/src/repository/hard_reset.ts
@@ -1,4 +1,4 @@
-import { Stats } from "fs";
+import { Stats } from "node:fs";
 import { Blob } from "../database";
 import { OID, Pathname } from "../types";
 import { posixPath } from "../util/fs";

--- a/packages/core/src/repository/inspector.ts
+++ b/packages/core/src/repository/inspector.ts
@@ -1,4 +1,4 @@
-import { Stats } from "fs";
+import { Stats } from "node:fs";
 import { Repository } from "./repository";
 import { Pathname } from "../types";
 import * as Index from "../gindex";

--- a/packages/core/src/repository/migration.test.ts
+++ b/packages/core/src/repository/migration.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, beforeAll, afterAll, vi } from "vitest";
 import type { MockInstance } from "vitest";
-import { constants } from "fs";
+import { constants } from "node:fs";
 import assert from "node:assert";
 import { makeDummyFileStats } from "../__test__";
 import { setOid } from "../__test__/util";

--- a/packages/core/src/repository/migration.ts
+++ b/packages/core/src/repository/migration.ts
@@ -1,5 +1,5 @@
-import { Stats } from "fs";
-import * as path from "path";
+import { Stats } from "node:fs";
+import * as path from "node:path";
 import * as Database from "../database";
 import * as Index from "../gindex";
 import { OID, Pathname } from "../types";

--- a/packages/core/src/repository/pending_commit.ts
+++ b/packages/core/src/repository/pending_commit.ts
@@ -1,5 +1,5 @@
-import { O_CREAT, O_EXCL, O_WRONLY } from "constants";
-import * as path from "path";
+import { O_CREAT, O_EXCL, O_WRONLY } from "node:constants";
+import * as path from "node:path";
 import { FileService, exists } from "../services";
 import { OID, Pathname } from "../types";
 import { BaseError } from "../util";

--- a/packages/core/src/repository/repository.test.ts
+++ b/packages/core/src/repository/repository.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import { Refs } from "../refs";
 import { Environment } from "../types";

--- a/packages/core/src/repository/repository.ts
+++ b/packages/core/src/repository/repository.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { Stack } from "../config";
 import { ChangeMap, Database } from "../database";
 import { Index } from "../gindex/index";

--- a/packages/core/src/repository/sequencer.ts
+++ b/packages/core/src/repository/sequencer.ts
@@ -1,5 +1,5 @@
-import * as fsCallback from "fs";
-import * as path from "path";
+import * as fsCallback from "node:fs";
+import * as path from "node:path";
 import { SequencerOptions as Options } from "./sequencer_options";
 import { Config } from "../config";
 import { Lockfile } from "../lockfile";

--- a/packages/core/src/repository/status.ts
+++ b/packages/core/src/repository/status.ts
@@ -1,4 +1,4 @@
-import { Stats } from "fs";
+import { Stats } from "node:fs";
 import * as Database from "../database";
 import * as Index from "../gindex";
 import { Stage } from "../gindex";

--- a/packages/core/src/rev_list.ts
+++ b/packages/core/src/rev_list.ts
@@ -1,4 +1,4 @@
-import path = require("path");
+import path = require("node:path");
 import * as Database from "./database";
 import { PathFilter } from "./path_filter";
 import { SymRef } from "./refs";

--- a/packages/core/src/revision.test.ts
+++ b/packages/core/src/revision.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   Ref,
   Parent,

--- a/packages/core/src/services/Logger.ts
+++ b/packages/core/src/services/Logger.ts
@@ -1,4 +1,4 @@
-import { Console } from "console";
+import { Console } from "node:console";
 
 export type Logger = {
   level: "debug" | "info" | "warn" | "error";

--- a/packages/core/src/tempfile.test.ts
+++ b/packages/core/src/tempfile.test.ts
@@ -1,3 +1,4 @@
+import { it } from "vitest";
 import assert from "node:assert";
 import { charsFromRange } from "./tempfile.ts";
 

--- a/packages/core/src/util/arg.test.ts
+++ b/packages/core/src/util/arg.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import arg from "./arg";
 
 describe("arg shim", () => {

--- a/packages/core/src/util/collection.test.ts
+++ b/packages/core/src/util/collection.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "vitest";
 import assert from "node:assert";
 import { ObjectKeyHash } from "./collection";
 

--- a/packages/core/src/util/fs.test.ts
+++ b/packages/core/src/util/fs.test.ts
@@ -1,4 +1,5 @@
-import * as path from "path";
+import { describe, it, beforeAll } from "vitest";
+import * as path from "node:path";
 import assert from "node:assert";
 import {
   ascend,

--- a/packages/core/src/util/fs.ts
+++ b/packages/core/src/util/fs.ts
@@ -1,9 +1,9 @@
 /**
  * File system / path 周りのユーティリティ
  */
-import { constants, Stats } from "fs";
-import { FileHandle, open } from "fs/promises";
-import * as path from "path";
+import { constants, Stats } from "node:fs";
+import { FileHandle, open } from "node:fs/promises";
+import * as path from "node:path";
 import { Pathname } from "../types";
 import { asserts } from "./assert";
 

--- a/packages/core/src/util/shlex.test.ts
+++ b/packages/core/src/util/shlex.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import { quote, split } from "./shlex";
 
 describe("shlex.split", () => {

--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import type { Mock } from "vitest";
-import { Stats } from "fs";
+import { Stats } from "node:fs";
 import * as path from "node:path";
 import assert from "node:assert";
 import { assertAsyncError, ENOENT, mockFsError } from "./__test__";

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -1,6 +1,6 @@
-import { O_CREAT, O_EXCL, O_WRONLY } from "constants";
-import { Stats } from "fs";
-import * as path from "path";
+import { O_CREAT, O_EXCL, O_WRONLY } from "node:constants";
+import { Stats } from "node:fs";
+import * as path from "node:path";
 import { ModeNumber } from "./entry";
 import { Changes, Migration } from "./repository";
 import { defaultFs, FileService, mkdirp, rmrf } from "./services";

--- a/packages/core/tsconfig.prod.json
+++ b/packages/core/tsconfig.prod.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "declaration": true
+    "declaration": true,
+    "sourceMap": true
   }
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     ],
   },
   test: {
-    globals: true,
     server: {
       deps: {
         // CJS パッケージを vite で変換させ、namespace import を callable として扱えるようにする

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "strict": true,
     "allowImportingTsExtensions": true,
     "lib": ["ES2024"],
-    "types": ["node", "vitest/globals"],
+    "types": ["node"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "Node16"


### PR DESCRIPTION
## Summary

開発体験まわりの 3 件をまとめて整理:

### 1. Node 標準ライブラリ import に `node:` プレフィックス
`fs` / `path` / `crypto` / `child_process` / `url` / `os` / `util` / `stream` / `events` / `zlib` / `assert` / `constants` / `fs/promises` 等を **53 ファイル** で `node:` 形式に書き換え。

### 2. vitest globals を廃止し explicit import に統一
- `tsconfig.base.json`: `types` から `vitest/globals` を除外
- `packages/{core,cli}/vitest.config.ts`: `globals: true` を削除
- 全テスト/ヘルパーファイル (49 件) に `import { describe, it, ... } from "vitest"` を追加

VS Code TS Server で発生していた `Cannot find name 'describe'` を根本解決。タイポ即検出 / ファイル単位で自己完結 / pnpm hoisting 非依存 のメリット。

### 3. VS Code デバッグ構成と source map で開発体験を整備
- `.vscode/settings.json`: workspace TypeScript SDK を強制 (bundled 古い TS が使われて `node:fs` を解釈できなかった問題を解消)
- `.vscode/launch.json`: monorepo 用に書き直し (旧 jest/dist パス廃棄)。kit 実行 / vitest current file / vitest unit / vitest integ の 4 構成
- `.vscode/tasks.json` (新規): launch の preLaunchTask 用
- `packages/{core,cli}/tsconfig.prod.json`: `sourceMap: true` を追加 — debug 時に dist の JS ではなく src の TS で停まる

## Commits

1. `chore: VS Code デバッグ構成と source map で開発体験を整備`
2. `refactor: node: プレフィックス導入と vitest globals 廃止`

## Test plan

- [x] `pnpm exec tsc -b` (project references) 0 error
- [x] `pnpm test:unit` core 242 + cli 3 passed
- [x] `pnpm test:integ` 375 passed (4 skip)
- [x] `pnpm lint` 0 warnings, 0 errors
- [x] `pnpm format:check` ✓
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)