### PR TITLE
chore(deps): TypeScript を 5.8.3 → 6.0.3 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "husky": "^4.3.8",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.62.0",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.62.0
         version: 1.62.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.15.17)(vite@8.0.10(@types/node@22.15.17))
@@ -797,8 +797,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1481,7 +1481,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typescript@5.8.3: {}
+  typescript@6.0.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary

TypeScript をメジャーバージョンアップ (`^5.8.3` → `^6.0.3`)。kit のソースコードは無修正で通過。

## Test plan

- [x] `pnpm exec tsc -b` 0 error
- [x] `pnpm test:unit` 245 passed (4 skip)
- [x] `pnpm test:integ` 375 passed (4 skip)
- [x] `pnpm lint` 0 errors
- [x] `pnpm format:check` ✓
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)