### PR TITLE
docs: README の test 手順を yarn から pnpm に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ kit config
 pnpm watch
 
 # test (unit & integ)
-yarn test:unit
-yarn test:integ
-yarn test:all
+pnpm test:unit
+pnpm test:integ
+pnpm test:all
 ```


### PR DESCRIPTION
## 概要

README の Development セクションで build は `pnpm watch` なのに test は `yarn test:*` と package manager が混在していたため、`pnpm` に統一しました。

```diff
-yarn test:unit
-yarn test:integ
-yarn test:all
+pnpm test:unit
+pnpm test:integ
+pnpm test:all
```

## 動作確認

`pnpm test:unit/integ/all` がスクリプトを正しく解決し vitest を起動することを確認。

> [!NOTE]
> なお `pnpm test:all` 自体は vitest4 × std-env の `ERR_REQUIRE_ESM` で失敗しますが、これは本変更前の main でも再現する既存の別問題で、本 PR の範囲外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)